### PR TITLE
Make the detail field of an Error optional

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,6 +17,7 @@ pub struct ErrorList {
 pub struct Error {
     code: String,
     message: String,
+    #[serde(default)]
     detail: serde_json::Value,
 }
 


### PR DESCRIPTION
I believe this fixes #3 